### PR TITLE
Run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update \
     && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \ 
     make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python \
     perl-test-longstring perl-list-moreutils perl-http-message \
-    geoip-dev
+    geoip-dev sudo
 
 ENV ZMQ_VERSION 4.0.5
 ENV CZMQ_VERSION 2.2.0
@@ -41,10 +41,11 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
          && make && make install \
          && apk del automake autoconf \
          && rm -rf /tmp/zeromq* && rm -rf /tmp/czmq* \
-         && rm -rf /var/cache/apk/*
+         && rm -rf /var/cache/apk/* 
 
 # openresty build
 ENV OPENRESTY_VERSION=1.9.7.3 \
+    NAXSI_VERSION=0.53-2 \
     PCRE_VERSION=8.37 \
     TEST_NGINX_VERSION=0.24 \
     _prefix=/usr/local \
@@ -53,17 +54,19 @@ ENV OPENRESTY_VERSION=1.9.7.3 \
     _sysconfdir=/etc \
     _sbindir=/usr/local/sbin
 
-RUN  echo " ... adding Openresty, NGINX, and PCRE" \
+RUN  echo " ... adding Openresty, NGINX, NAXSI and PCRE" \
      && mkdir -p /tmp/api-gateway \
      && readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
      && echo "using up to $NPROC threads" \
 
      && cd /tmp/api-gateway/ \
+     && curl -k -L https://github.com/nbs-system/naxsi/archive/${NAXSI_VERSION}.tar.gz -o /tmp/api-gateway/naxsi-${NAXSI_VERSION}.tar.gz \
      && curl -k -L http://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VERSION}/pcre-${PCRE_VERSION}.tar.gz -o /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz \
      && curl -k -L https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz -o /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz \
      && tar -zxf ./openresty-${OPENRESTY_VERSION}.tar.gz \
      && tar -zxf ./pcre-${PCRE_VERSION}.tar.gz \
-     && cd /tmp/api-gateway/openresty-${OPENRESTY_VERSION} \
+     && tar -zxf ./naxsi-${NAXSI_VERSION}.tar.gz \
+     && cd /tmp/api-gateway/openresty-${OPENRESTY_VERSION} \ 
 
      && echo "        - building debugging version of the api-gateway ... " \
      && ./configure \
@@ -74,6 +77,7 @@ RUN  echo " ... adding Openresty, NGINX, and PCRE" \
             --http-log-path=${_localstatedir}/log/api-gateway/access.log \
             --pid-path=${_localstatedir}/run/api-gateway.pid \
             --lock-path=${_localstatedir}/run/api-gateway.lock \
+            --add-module=../naxsi-${NAXSI_VERSION}/naxsi_src/ \
             --with-pcre=../pcre-${PCRE_VERSION}/ --with-pcre-jit \
             --with-stream \
             --with-stream_ssl_module \
@@ -111,6 +115,7 @@ RUN  echo " ... adding Openresty, NGINX, and PCRE" \
             --http-log-path=${_localstatedir}/log/api-gateway/access.log \
             --pid-path=${_localstatedir}/run/api-gateway.pid \
             --lock-path=${_localstatedir}/run/api-gateway.lock \
+            --add-module=../naxsi-${NAXSI_VERSION}/naxsi_src/ \
             --with-pcre=../pcre-${PCRE_VERSION}/ --with-pcre-jit \
             --with-stream \
             --with-stream_ssl_module \
@@ -270,7 +275,7 @@ RUN echo " ... installing api-gateway-aws ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV REQUEST_VALIDATION_VERSION 1.2.0
+ENV REQUEST_VALIDATION_VERSION 1.1.1
 RUN echo " ... installing api-gateway-request-validation ..." \
     && apk update \
     && apk add make \
@@ -304,7 +309,7 @@ RUN echo " ... installing api-gateway-async-logger ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ZMQ_ADAPTOR_VERSION 0.2.1
+ENV ZMQ_ADAPTOR_VERSION 0.1.1
 RUN echo " ... installing api-gateway-zmq-adaptor" \
          && curl -L https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
          && apk update \
@@ -353,14 +358,27 @@ RUN \
     && chmod 755 /usr/local/bin/jq \
     && rm -rf /var/cache/apk/*
 
+RUN addgroup apiplatform && \
+   adduser -D -G apiplatform apiplatform 
+
 COPY init.sh /etc/init-container.sh
 ONBUILD COPY init.sh /etc/init-container.sh
 
 # add the default configuration for the Gateway
 COPY api-gateway-config /etc/api-gateway
 RUN adduser -S nginx-api-gateway \
-    && addgroup -S nginx-api-gateway
+    && adduser nginx-api-gateway apiplatform \
+    && addgroup -S nginx-api-gateway \
+    && mkdir -p /usr/local/api-gateway \
+    && chown -R apiplatform:apiplatform /etc/api-gateway /var/log/api-gateway /usr/local \
+    && chown root.apiplatform /var/run \
+    && chmod 775 /var/run \
+    && chmod 775 -R /etc/api-gateway \
+    && chmod 4755 /bin/busybox \
+    && echo "apiplatform ALL=(ALL) NOPASSWD: /bin/chown" >> /etc/sudoers
+
 ONBUILD COPY api-gateway-config /etc/api-gateway
 
+USER apiplatform
 
 ENTRYPOINT ["/etc/init-container.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update \
     && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \ 
     make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python \
     perl-test-longstring perl-list-moreutils perl-http-message \
-    geoip-dev sudo iptables
+    geoip-dev sudo
 
 ENV ZMQ_VERSION 4.0.5
 ENV CZMQ_VERSION 2.2.0

--- a/api-gateway-config/conf.d/default.conf
+++ b/api-gateway-config/conf.d/default.conf
@@ -21,7 +21,7 @@
 # *
 # */
 server {
-    listen 80 default_server;
+    listen 8080 default_server;
 
     server_tokens off;
 

--- a/api-gateway-config/conf.d/default.conf
+++ b/api-gateway-config/conf.d/default.conf
@@ -21,7 +21,7 @@
 # *
 # */
 server {
-    listen 8080 default_server;
+    listen 80 default_server;
 
     server_tokens off;
 

--- a/api-gateway-config/conf.d/marathon_apis.conf
+++ b/api-gateway-config/conf.d/marathon_apis.conf
@@ -29,8 +29,8 @@
 include /etc/api-gateway/environment.conf.d/api-gateway-upstreams.http.conf;
 
 server {
-    listen 80;
-#    listen 8080;
+#    listen 80;
+    listen 8080;
 
     # listenes on <marathon_app_name>.api.any.domain with the assumption that the marathon_app_name has been defined in marathon. TBD what to do when the app is not found
     server_name ~^(?<marathon_app_name>.[^\.]+)\.(api|gw)\.(?<domain>.+);

--- a/api-gateway-config/conf.d/marathon_apis.conf
+++ b/api-gateway-config/conf.d/marathon_apis.conf
@@ -29,8 +29,7 @@
 include /etc/api-gateway/environment.conf.d/api-gateway-upstreams.http.conf;
 
 server {
-#    listen 80;
-    listen 8080;
+    listen 80;
 
     # listenes on <marathon_app_name>.api.any.domain with the assumption that the marathon_app_name has been defined in marathon. TBD what to do when the app is not found
     server_name ~^(?<marathon_app_name>.[^\.]+)\.(api|gw)\.(?<domain>.+);

--- a/init.sh
+++ b/init.sh
@@ -49,7 +49,6 @@ function start_zmq_adaptor()
     sleep 3s
     # allow interprocess communication by allowing api-gateway processes to write to the socket
     sudo /bin/chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_listen
-    sudo /bin/chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_push
 }
 # keep the zmq adaptor running using a simple loop
 while true; do zmq_pid=$(ps aux | grep api-gateway-zmq-adaptor | grep -v grep) || ( echo "Restarting api-gateway-zmq-adaptor" && start_zmq_adaptor ); sleep 60; done &

--- a/init.sh
+++ b/init.sh
@@ -45,7 +45,7 @@ function start_zmq_adaptor()
         zmq_adaptor_cmd="${zmq_adaptor_cmd} -d"
     fi
 
-    $zmq_adaptor_cmd >> /dev/stderr &
+    sudo $zmq_adaptor_cmd >> /dev/stderr &
     sleep 3s
     # allow interprocess communication by allowing api-gateway processes to write to the socket
     sudo /bin/chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_listen
@@ -61,7 +61,7 @@ if [ "${debug_mode}" == "true" ]; then
     ln -sf /usr/local/sbin/api-gateway-debug /usr/local/sbin/api-gateway
 fi
 
-/usr/local/sbin/api-gateway -V
+sudo /usr/local/sbin/api-gateway -V
 echo "------"
 
 echo resolver $(awk 'BEGIN{ORS=" "} /nameserver/{print $2}' /etc/resolv.conf | sed "s/ $/;/g") > /etc/api-gateway/conf.d/includes/resolvers.conf
@@ -77,7 +77,7 @@ if [[ -n "${remote_config}" ]]; then
       echo "   ... but this REMOTE_CONFIG is not supported "
     fi
 fi
-api-gateway-config-supervisor \
+sudo api-gateway-config-supervisor \
         --reload-cmd="api-gateway -s reload" \
         --sync-folder=/etc/api-gateway \
         --sync-interval=${remote_config_sync_interval} \
@@ -101,7 +101,7 @@ if [[ -n "${marathon_host}" ]]; then
 fi
 
 echo "   ... testing configuration "
-api-gateway -t -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf
+sudo api-gateway -t -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf
 
 echo "   ... using log level: '${log_level}'. Override it with -e 'LOG_LEVEL=<level>' "
-api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "daemon off; error_log /dev/stderr ${log_level};"
+sudo api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "daemon off; error_log /dev/stderr ${log_level};"

--- a/init.sh
+++ b/init.sh
@@ -48,7 +48,8 @@ function start_zmq_adaptor()
     $zmq_adaptor_cmd >> /dev/stderr &
     sleep 3s
     # allow interprocess communication by allowing api-gateway processes to write to the socket
-    chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_listen
+    sudo /bin/chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_listen
+    sudo /bin/chown nginx-api-gateway:nginx-api-gateway /tmp/nginx_queue_push
 }
 # keep the zmq adaptor running using a simple loop
 while true; do zmq_pid=$(ps aux | grep api-gateway-zmq-adaptor | grep -v grep) || ( echo "Restarting api-gateway-zmq-adaptor" && start_zmq_adaptor ); sleep 60; done &


### PR DESCRIPTION
**Running container api-gateway service  as non-root user**
Reference : CIS 4.1 section. https://benchmarks.cisecurity.org/tools2/docker/CIS_Docker_1.11.0_Benchmark_v1.0.0.pdf 

By default docker containers run as root  and as user root inside the container.  A docker container running as root has full control of the host system. In order to run the docker container image as a non-root user and api-gateway service to continue to user port 80, following modifications are done to dockerfile and init.sh

**#install sudo in docker image**
geoip-dev sudo iptables

**#Add user and group (uid and gid 1000 for consistency)**
 RUN adduser -S nginx-api-gateway -u 1000 \
   && addgroup -S nginx-api-gateway -g 1000

**#apply non-root user to directories and files.** 
 RUN mkdir -p /usr/local/api-gateway \
   && chown -R nginx-api-gateway /etc/api-gateway /var/log/api-gateway /usr/local \ 
   && chmod 755 -R /etc/api-gateway /var/log/api-gateway /usr/local \
   && chmod 4755 /bin/busybox \
   && echo "nginx-api-gateway ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

**#USER instruction to specify a non-root user for container to run as**
USER nginx-api-gateway

After the above changes, the below command shows the container is running with user nginx-api-gateway  If it returns blank instead of username means, the container is running as root. 

**Example run**
docker ps --quiet | xargs docker inspect --format '{{ .Id }}: User={{.Config.User}}'
919da15af3df3f12d966659a37898b2dd4cbb7837f2989749adf14f6d430284c: **User=nginx-api-gateway**
