### PR TITLE
Fixing dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM alpine:3.4
 # install dependencies
 RUN apk update \
     && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \ 
-    make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python autoconf automake\
+    make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python \
     perl-test-longstring perl-list-moreutils perl-http-message \
     geoip-dev sudo
 
@@ -18,6 +18,7 @@ ENV CZMQ_VERSION 2.2.0
 
 # Installing throttling dependencies
 RUN echo " ... adding throttling support with ZMQ and CZMQ" \
+         && apk add autoconf automake \
          && curl -L https://github.com/zeromq/zeromq4-x/archive/v${ZMQ_VERSION}.tar.gz -o /tmp/zeromq.tar.gz \
          && cd /tmp/ \
          && tar -xf /tmp/zeromq.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
                         --sysconfdir=/etc \
                         --mandir=/usr/share/man \
                         --infodir=/usr/share/info \
-         && make && make install
+         && make && make install && make clean
 
 # openresty build
 ENV OPENRESTY_VERSION=1.9.7.3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
                         --sysconfdir=/etc \
                         --mandir=/usr/share/man \
                         --infodir=/usr/share/info \
-         && make && make install && make clean
+         && make && make install \
+         && apk del automake autoconf \
+         && rm -rf /tmp/zeromq* && rm -rf /tmp/czmq* \
+         && rm -rf /var/cache/apk/*
 
 # openresty build
 ENV OPENRESTY_VERSION=1.9.7.3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@
 # VERSION               1.9.7.3
 #
 # From https://hub.docker.com/_/alpine/
-#
-FROM alpine:latest
+# alpine:3.4 if go <1.7
+FROM alpine:3.4
 
 # install dependencies
 RUN apk update \
     && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \ 
-    make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python \
+    make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python autoconf automake\
     perl-test-longstring perl-list-moreutils perl-http-message \
     geoip-dev sudo
 
@@ -22,7 +22,6 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
          && cd /tmp/ \
          && tar -xf /tmp/zeromq.tar.gz \
          && cd /tmp/zeromq*/ \
-         && apk add automake autoconf \
          && ./autogen.sh \
          && ./configure --prefix=/usr \
                         --sysconfdir=/etc \
@@ -38,10 +37,7 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
                         --sysconfdir=/etc \
                         --mandir=/usr/share/man \
                         --infodir=/usr/share/info \
-         && make && make install \
-         && apk del automake autoconf \
-         && rm -rf /tmp/zeromq* && rm -rf /tmp/czmq* \
-         && rm -rf /var/cache/apk/*
+         && make && make install
 
 # openresty build
 ENV OPENRESTY_VERSION=1.9.7.3 \


### PR DESCRIPTION
FROM alpine:latest breaks the build. Based on current dependencies alpine 3.4 is used.
Also added some prerequisites for when alpine:latest will be used. There are still some c dependencies failing on alpine:latest but until then this should do trick.

Thanks.
@constantincristian @cristianconstantin please find the fix attached I also tested that this works on building
