### PR TITLE
access_log and error_log go to stdout and stderr

### DIFF
--- a/api-gateway-config/conf.d/marathon_apis.conf
+++ b/api-gateway-config/conf.d/marathon_apis.conf
@@ -49,8 +49,8 @@ server {
     include /etc/api-gateway/conf.d/includes/default_validators.conf;
 
     # Log locations with service name
-    access_log /var/log/api-gateway/access.log platform;
-    error_log /var/log/api-gateway/marathon_error.log debug;
+    access_log /dev/stdout platform;
+    error_log /dev/stderr info;
 
     # include environment variables
     include /etc/api-gateway/environment.conf.d/api-gateway-env-vars.server.conf;


### PR DESCRIPTION
for the generic proxy of Marathon APIs