### PR TITLE
Verify tasks retrieval prior to parsing and replacing upstreams config

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -88,7 +88,7 @@ if [[ -n "${marathon_host}" ]]; then
     echo "  ... starting Marathon Service Discovery on ${marathon_host}"
     touch /var/run/apigateway-config-watcher.lastrun
     # start marathon's service discovery
-    while true; do /etc/api-gateway/marathon-service-discovery.sh > /dev/stderr; sleep ${sleep_duration}; done &
+    while true; do sh /etc/api-gateway/marathon-service-discovery.sh > /dev/stderr; sleep ${sleep_duration}; done &
     # start simple statsd logger
     #
     # ASSUMPTION: there is a graphite app named "api-gateway-graphite" deployed in marathon


### PR DESCRIPTION
In the case of connectivity failure, (ex: DNS failure is exit code `6`) skip generation + reload of new upstreams configuration.