### PR TITLE
updated go and config supervisor versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,14 +177,14 @@ RUN echo " ... installing lua-resty-iputils..." \
     && $INSTALL lib/resty/*.lua ${LUA_LIB_DIR}/resty/ \
     && rm -rf /tmp/api-gateway
 
-ENV CONFIG_SUPERVISOR_VERSION 1.0.1-RC1
+ENV CONFIG_SUPERVISOR_VERSION 1.0.3
 ENV GOPATH /usr/lib/go/bin
 ENV GOBIN  /usr/lib/go/bin
 ENV PATH   $PATH:/usr/lib/go/bin
 RUN echo " ... installing api-gateway-config-supervisor  ... " \
     && echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk update \
-    && apk add gcc make git 'go<1.7' \
+    && apk add gcc make git 'go' \
     && mkdir -p /tmp/api-gateway \
     && curl -k -L https://github.com/adobe-apiplatform/api-gateway-config-supervisor/archive/${CONFIG_SUPERVISOR_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
     && cd /tmp/api-gateway \

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ What's inside
 
 |   Module     |   Version  |  Description |
 |--------------|------------|--------------|
-| [api-gateway-config-supervisor](https://github.com/adobe-apiplatform/api-gateway-config-supervisor) | [1.0.0](https://github.com/adobe-apiplatform/api-gateway-config-supervisor/releases/tag/1.0.0) | Syncs config files from Amazon S3 reloading the gateway with the updates |
+| [api-gateway-config-supervisor](https://github.com/adobe-apiplatform/api-gateway-config-supervisor) | [1.0.3](https://github.com/adobe-apiplatform/api-gateway-config-supervisor/releases/tag/1.0.3) | Syncs config files from Amazon S3 reloading the gateway with the updates |
 | [api-gateway-cachemanager](https://github.com/adobe-apiplatform/api-gateway-cachemanager) | [1.0.1](https://github.com/adobe-apiplatform/api-gateway-cachemanager/releases/tag/1.0.1) | Lua library for managing multiple cache stores |
 | [api-gateway-hmac](https://github.com/adobe-apiplatform/api-gateway-hmac) | [1.0.0](https://github.com/adobe-apiplatform/api-gateway-hmac/releases/tag/1.0.0) | HMAC support for Lua with multiple algorithms, via OpenSSL and FFI |
 | [api-gateway-aws](https://github.com/adobe-apiplatform/api-gateway-aws) | [1.7.1](https://github.com/adobe-apiplatform/api-gateway-aws/releases/tag/1.7.1) | AWS SDK for Nginx in Lua |


### PR DESCRIPTION
- [x] Removed restriction to `go<1.7`
- [x] Updated Config Supervisor to [1.0.3](https://github.com/adobe-apiplatform/api-gateway-config-supervisor/releases/tag/1.0.3)