### PR TITLE
Dockerfile:checksums+gofix+alpine3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ RUN apk update \
     perl-test-longstring perl-list-moreutils perl-http-message \
     geoip-dev sudo
 
-ENV ZMQ_VERSION=4.0.5 \
-    ZMQ_SHA256=e3dc99aeacd4e1e7a025f22f92afec6c381b82f0e29222d27e1256ada841e43f
-ENV CZMQ_VERSION=2.2.0 \
-    CZMQ_SHA256=3c95aab7434ac0a074a46217122c9f454c36befcd0b5aaa1f463aae0838dd499
+ENV ZMQ_VERSION 4.0.5
+ENV CZMQ_VERSION 2.2.0
 
 # Installing throttling dependencies
 RUN echo " ... adding throttling support with ZMQ and CZMQ" \
+         && ZMQ_SHA256=e3dc99aeacd4e1e7a025f22f92afec6c381b82f0e29222d27e1256ada841e43f \
+         && CZMQ_SHA256=3c95aab7434ac0a074a46217122c9f454c36befcd0b5aaa1f463aae0838dd499 \
          && apk add autoconf automake \
          && curl -sL https://github.com/zeromq/zeromq4-x/archive/v${ZMQ_VERSION}.tar.gz -o /tmp/zeromq.tar.gz \
          && echo "${ZMQ_SHA256}  /tmp/zeromq.tar.gz" | sha256sum -c - \
@@ -47,30 +47,29 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
          && rm -rf /tmp/zeromq* && rm -rf /tmp/czmq* \
          && rm -rf /var/cache/apk/*
 
-# openresty build
-ENV OPENRESTY_VERSION=1.13.6.1 \
-    OPENRESTY_SHA256=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b
-ENV PCRE_VERSION=8.37 \
-    PCRE_SHA256=19d490a714274a8c4c9d131f651489b8647cdb40a159e9fb7ce17ba99ef992ab
-ENV TEST_NGINX_VERSION=0.24 \
-    TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3
 ENV _prefix=/usr/local \
     _exec_prefix=/usr/local \
     _localstatedir=/var \
     _sysconfdir=/etc \
     _sbindir=/usr/local/sbin
 
-RUN  echo " ... adding Openresty, NGINX, and PCRE" \
-     && mkdir -p /tmp/api-gateway \
+# openresty build
+ENV OPENRESTY_VERSION 1.13.6.1
+ENV PCRE_VERSION 8.37
+RUN  echo " ... adding Openresty and PCRE" \
+     && OPENRESTY_SHA256=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b \
+     && PCRE_SHA256=19d490a714274a8c4c9d131f651489b8647cdb40a159e9fb7ce17ba99ef992ab \
      \
+     && mkdir -p /tmp/api-gateway \
      && cd /tmp/api-gateway/ \
      && curl -sL https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/pcre-${PCRE_VERSION}.tar.gz -o /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz \
      && echo "${PCRE_SHA256}  /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz" | sha256sum -c - \
      && curl -sL https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/openresty-${OPENRESTY_VERSION}.tar.gz -o /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz \
      && echo "${OPENRESTY_SHA256}  /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz" | sha256sum -c - \
      && tar -zxf ./openresty-${OPENRESTY_VERSION}.tar.gz \
-     && tar -zxf ./pcre-${PCRE_VERSION}.tar.gz
-RUN readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
+     && tar -zxf ./pcre-${PCRE_VERSION}.tar.gz \
+     \
+     && readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
      && echo "using up to $NPROC threads" \
      && cd /tmp/api-gateway/openresty-${OPENRESTY_VERSION} \
      && echo "        - building debugging version of the api-gateway ... " \
@@ -145,7 +144,9 @@ RUN readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
     && make -j${NPROC} \
     && make install
 
-RUN echo "        - adding Nginx Test support" \
+ENV TEST_NGINX_VERSION 0.24
+RUN echo " ... adding Nginx Test support..." \
+    && TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3 \
     && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz" | sha256sum -c - \
     && cd ${_prefix} \
@@ -158,9 +159,9 @@ RUN echo "        - adding Nginx Test support" \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV LUA_RESTY_HTTP_VERSION=0.07 \
-    LUA_RESTY_HTTP_SHA256=1c6aa06c9955397c94e9c3e0c0fba4e2704e85bee77b4512fb54ae7c25d58d86
+ENV LUA_RESTY_HTTP_VERSION 0.07
 RUN echo " ... installing lua-resty-http..." \
+    && LUA_RESTY_HTTP_SHA256=1c6aa06c9955397c94e9c3e0c0fba4e2704e85bee77b4512fb54ae7c25d58d86 \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -173,9 +174,9 @@ RUN echo " ... installing lua-resty-http..." \
             INSTALL=${_prefix}/api-gateway/bin/resty-install \
     && rm -rf /tmp/api-gateway
 
-ENV LUA_RESTY_IPUTILS_VERSION=0.2.0 \
-    LUA_RESTY_IPUTILS_SHA256=7962557ff3070154a45c5192d927b26106ec2f411fd1a98eaf770bc23189799d
+ENV LUA_RESTY_IPUTILS_VERSION 0.2.0
 RUN echo " ... installing lua-resty-iputils..." \
+    && LUA_RESTY_IPUTILS_SHA256=7962557ff3070154a45c5192d927b26106ec2f411fd1a98eaf770bc23189799d \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -189,13 +190,12 @@ RUN echo " ... installing lua-resty-iputils..." \
     && $INSTALL lib/resty/*.lua ${LUA_LIB_DIR}/resty/ \
     && rm -rf /tmp/api-gateway
 
-ENV CONFIG_SUPERVISOR_VERSION=1.0.3 \
-    CONFIG_SUPERVISOR_SHA256=9a323d93897140f3ccb384a7279335d69f5659d1d29564b21f3d056f42272bdb
-
+ENV CONFIG_SUPERVISOR_VERSION 1.0.3
 ENV GOPATH /usr/lib/go/bin
 ENV GOBIN  /usr/lib/go/bin
 ENV PATH   $PATH:/usr/lib/go/bin
 RUN echo " ... installing api-gateway-config-supervisor  ... " \
+    && CONFIG_SUPERVISOR_SHA256=9a323d93897140f3ccb384a7279335d69f5659d1d29564b21f3d056f42272bdb \
     && echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk update \
     && apk add gcc make git 'go' \
@@ -214,11 +214,11 @@ RUN echo " ... installing api-gateway-config-supervisor  ... " \
     && ln -s /tmp/go /tmp/go-src/src/github.com/adobe-apiplatform/api-gateway-config-supervisor \
     && GOPATH=/tmp/go/vendor:/tmp/go-src CGO_ENABLED=0 GOOS=linux /usr/lib/go/bin/godep  go build -ldflags "-s" -a -installsuffix cgo -o api-gateway-config-supervisor ./ \
     && mv /tmp/go/api-gateway-config-supervisor /usr/local/sbin/ \
-
+    \
     && echo "installing rclone sync ... skipped due to https://github.com/ncw/rclone/issues/663 ... " \
     # && go get github.com/ncw/rclone \
     # && mv /usr/lib/go/bin/rclone /usr/local/sbin/ \
-
+    \
     && echo " cleaning up ... " \
     && rm -rf /usr/lib/go/bin/src \
     && rm -rf /tmp/go \
@@ -235,9 +235,9 @@ RUN echo " ... installing aws-cli ..." \
     && pip install --upgrade pip \
     && pip install awscli
 
-ENV HMAC_LUA_VERSION=1.0.0 \
-    HMAC_LUA_SHA256=53e6183cb3812418b55b9afba256f6d1f149cdd994c0c19df3bb70ac56310281
+ENV HMAC_LUA_VERSION 1.0.0
 RUN echo " ... installing api-gateway-hmac ..." \
+    && HMAC_LUA_SHA256=53e6183cb3812418b55b9afba256f6d1f149cdd994c0c19df3bb70ac56310281 \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -252,9 +252,9 @@ RUN echo " ... installing api-gateway-hmac ..." \
             INSTALL=${_prefix}/api-gateway/bin/resty-install \
     && rm -rf /tmp/api-gateway
 
-ENV CACHE_MANAGER_VERSION=1.0.1 \
-    CACHE_MANAGER_SHA256=8d03c1b4a9b3d6ca9fcbf941c42c5795d12fe2fd3d2e58b56e33888acb993f26
+ENV CACHE_MANAGER_VERSION 1.0.1
 RUN echo " ... installing api-gateway-cachemanager..." \
+    && CACHE_MANAGER_SHA256=8d03c1b4a9b3d6ca9fcbf941c42c5795d12fe2fd3d2e58b56e33888acb993f26 \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -272,9 +272,9 @@ RUN echo " ... installing api-gateway-cachemanager..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV AWS_VERSION=1.7.1 \
-    AWS_SHA256=d9fadd6602e2c139d389bd64329c72c129f76ad1d1c1857c2e4a3537d01e12fe
+ENV AWS_VERSION 1.7.1
 RUN echo " ... installing api-gateway-aws ..." \
+    && AWS_SHA256=d9fadd6602e2c139d389bd64329c72c129f76ad1d1c1857c2e4a3537d01e12fe \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -290,9 +290,9 @@ RUN echo " ... installing api-gateway-aws ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV REQUEST_VALIDATION_VERSION=1.2.4 \
-    REQUEST_VALIDATION_SHA256=44ebce6119b6d3e1405a1fc203d97c9cb64d4a37ee8e26e00a0eec2b5814e176
+ENV REQUEST_VALIDATION_VERSION 1.2.4
 RUN echo " ... installing api-gateway-request-validation ..." \
+    && REQUEST_VALIDATION_SHA256=44ebce6119b6d3e1405a1fc203d97c9cb64d4a37ee8e26e00a0eec2b5814e176 \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -310,9 +310,9 @@ RUN echo " ... installing api-gateway-request-validation ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ASYNC_LOGGER_VERSION=1.0.1 \
-    ASYNC_LOGGER_SHA256=de5e008d189daa619a189a8bb530ed1c58c29f8bf07903b26b818dadd4bcc8fa
+ENV ASYNC_LOGGER_VERSION 1.0.1
 RUN echo " ... installing api-gateway-async-logger ..." \
+    && ASYNC_LOGGER_SHA256=de5e008d189daa619a189a8bb530ed1c58c29f8bf07903b26b818dadd4bcc8fa \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
@@ -328,9 +328,9 @@ RUN echo " ... installing api-gateway-async-logger ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ZMQ_ADAPTOR_VERSION=0.2.1 \
-    ZMQ_ADAPTOR_SHA256=10cc0fd0b431931c8d05ab112e7e8e76aaf8848af5f3e48adf41d4bd0e329272
+ENV ZMQ_ADAPTOR_VERSION 0.2.1
 RUN echo " ... installing api-gateway-zmq-adaptor" \
+         && ZMQ_ADAPTOR_SHA256=10cc0fd0b431931c8d05ab112e7e8e76aaf8848af5f3e48adf41d4bd0e329272 \
          && curl -sL https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
          && echo "${ZMQ_ADAPTOR_SHA256}  /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION}" | sha256sum -c - \
          && apk update \
@@ -344,9 +344,9 @@ RUN echo " ... installing api-gateway-zmq-adaptor" \
          && apk del check-dev g++ gcc \
          && rm -rf /var/cache/apk/*
 
-ENV ZMQ_LOGGER_VERSION=1.0.0 \
-    ZMQ_LOGGER_SHA256=76afbe17397881719bf24775747276231841274976708cca8d3b37d6b95e61c8
+ENV ZMQ_LOGGER_VERSION 1.0.0
 RUN echo " ... installing api-gateway-zmq-logger ..." \
+        && ZMQ_LOGGER_SHA256=76afbe17397881719bf24775747276231841274976708cca8d3b37d6b95e61c8 \
         && mkdir -p /tmp/api-gateway \
         && curl -sL https://github.com/adobe-apiplatform/api-gateway-zmq-logger/archive/${ZMQ_LOGGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz \
         && echo "${ZMQ_LOGGER_SHA256}  /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz" | sha256sum -c - \
@@ -359,9 +359,9 @@ RUN echo " ... installing api-gateway-zmq-logger ..." \
              INSTALL=/usr/local/api-gateway/bin/resty-install \
         && rm -rf /tmp/api-gateway
 
-ENV REQUEST_TRACKING_VERSION=1.0.1 \
-    REQUEST_TRACKING_SHA256=6508d4eb444e0ae46bef262e0dd1def25f5762993e1810c21f1603ec57ce8895
+ENV REQUEST_TRACKING_VERSION 1.0.1
 RUN echo " ... installing api-gateway-request-tracking ..." \
+        && REQUEST_TRACKING_SHA256=6508d4eb444e0ae46bef262e0dd1def25f5762993e1810c21f1603ec57ce8895 \
         && mkdir -p /tmp/api-gateway \
         && curl -sL https://github.com/adobe-apiplatform/api-gateway-request-tracking/archive/${REQUEST_TRACKING_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz \
         && echo "${REQUEST_TRACKING_SHA256}  /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz" | sha256sum -c - \
@@ -376,9 +376,9 @@ RUN echo " ... installing api-gateway-request-tracking ..." \
         # && apk del redis \
         && rm -rf /tmp/api-gateway
 
-ENV JQ_VERSION=1.5 \
-    JQ_SHA256=c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+ENV JQ_VERSION 1.5
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -o /usr/local/bin/jq \
+    && JQ_SHA256=c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d \
     && echo "${JQ_SHA256}  /usr/local/bin/jq" | sha256sum -c - \
     && apk update \
     && apk add gawk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,15 +48,16 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
          && rm -rf /var/cache/apk/*
 
 ENV _prefix /usr/local
+
 # openresty build
 ENV OPENRESTY_VERSION 1.13.6.1
 ENV PCRE_VERSION 8.37
 RUN  echo " ... adding Openresty and PCRE" \
-     && OPENRESTY_SHA256=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b \
-     && PCRE_SHA256=19d490a714274a8c4c9d131f651489b8647cdb40a159e9fb7ce17ba99ef992ab \
      && _localstatedir=/var \
      && _sysconfdir=/etc \
-     && _sbindir=${_prefix}/sbin \
+     && _sbindir=/usr/local/sbin \
+     && OPENRESTY_SHA256=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b \
+     && PCRE_SHA256=19d490a714274a8c4c9d131f651489b8647cdb40a159e9fb7ce17ba99ef992ab \
      \
      && mkdir -p /tmp/api-gateway \
      && cd /tmp/api-gateway/ \
@@ -150,13 +151,12 @@ RUN  echo " ... adding Openresty and PCRE" \
 ENV TEST_NGINX_VERSION 0.24
 RUN echo " ... adding Nginx Test support..." \
     && TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3 \
-    && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx.tar.gz \
-    && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx.tar.gz" | sha256sum -c - \
+    && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
+    && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz" | sha256sum -c - \
     && cd ${_prefix} \
-    && tar -xf ${_prefix}/test-nginx.tar.gz \
-    && mv ${_prefix}/test-nginx-${TEST_NGINX_VERSION} ${_prefix}/test-nginx \
-    && rm ${_prefix}/test-nginx.tar.gz \
-    && cp -r ${_prefix}/test-nginx/inc/* /usr/local/share/perl5/site_perl/
+    && tar -xf ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
+    && rm ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
+    && cp -r ${_prefix}/test-nginx-${TEST_NGINX_VERSION}/inc/* /usr/local/share/perl5/site_perl/
 
 ENV LUA_RESTY_HTTP_VERSION 0.07
 RUN echo " ... installing lua-resty-http..." \
@@ -240,7 +240,7 @@ RUN echo " ... installing api-gateway-hmac ..." \
     && echo "${HMAC_LUA_SHA256}  /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION} \
-    && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+    && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
     && make test \
     && make install \
             LUA_LIB_DIR=${_prefix}/api-gateway/lualib \
@@ -257,7 +257,7 @@ RUN echo " ... installing api-gateway-cachemanager..." \
     && echo "${CACHE_MANAGER_SHA256}  /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION} \
-    && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+    && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
     # && apk update && apk add redis \
     # && REDIS_SERVER=/usr/bin/redis-server make test \
     && make install \
@@ -277,7 +277,7 @@ RUN echo " ... installing api-gateway-aws ..." \
     && echo "${AWS_SHA256}  /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-aws-${AWS_VERSION} \
-    && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+    && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
     # && make test \
     && make install \
             LUA_LIB_DIR=${_prefix}/api-gateway/lualib \
@@ -295,7 +295,7 @@ RUN echo " ... installing api-gateway-request-validation ..." \
     && echo "${REQUEST_VALIDATION_SHA256}  /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION} \
-    && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+    && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
     # && apk update && apk add redis \
     # && REDIS_SERVER=/usr/bin/redis-server make test \
     && make install \
@@ -315,7 +315,7 @@ RUN echo " ... installing api-gateway-async-logger ..." \
     && echo "${ASYNC_LOGGER_SHA256}  /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION} \
-    && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+    && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
     # && make test \
     && make install \
             LUA_LIB_DIR=${_prefix}/api-gateway/lualib \
@@ -347,7 +347,7 @@ RUN echo " ... installing api-gateway-zmq-logger ..." \
         && echo "${ZMQ_LOGGER_SHA256}  /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz" | sha256sum -c - \
         && tar -xf /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
         && cd /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION} \
-        && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+        && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
         && make test \
         && make install \
              LUA_LIB_DIR=/usr/local/api-gateway/lualib \
@@ -362,7 +362,7 @@ RUN echo " ... installing api-gateway-request-tracking ..." \
         && echo "${REQUEST_TRACKING_SHA256}  /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz" | sha256sum -c - \
         && tar -xf /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz -C /tmp/api-gateway/ \
         && cd /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION} \
-        && cp -r /usr/local/test-nginx/* ./test/resources/test-nginx/ \
+        && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
         # && apk update && apk add redis \
         # && REDIS_SERVER=/usr/bin/redis-server make test \
         && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,12 @@ RUN  echo " ... adding Openresty and PCRE" \
             --without-http_scgi_module \
             -j${NPROC} \
     && make -j${NPROC} \
-    && make install
+    && make install \
+    && ln -s ${_sbindir}/api-gateway-debug ${_sbindir}/nginx \
+    && cp /tmp/api-gateway/openresty-${OPENRESTY_VERSION}/build/install ${_prefix}/api-gateway/bin/resty-install \
+    && apk del g++ gcc make \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/api-gateway
 
 ENV TEST_NGINX_VERSION 0.24
 RUN echo " ... adding Nginx Test support..." \
@@ -152,12 +157,7 @@ RUN echo " ... adding Nginx Test support..." \
     && cd ${_prefix} \
     && tar -xf ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && rm ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
-    && cp -r ${_prefix}/test-nginx-0.24/inc/* /usr/local/share/perl5/site_perl/ \
-    && ln -s ${_sbindir}/api-gateway-debug ${_sbindir}/nginx \
-    && cp /tmp/api-gateway/openresty-${OPENRESTY_VERSION}/build/install ${_prefix}/api-gateway/bin/resty-install \
-    && apk del g++ gcc make \
-    && rm -rf /var/cache/apk/* \
-    && rm -rf /tmp/api-gateway
+    && cp -r ${_prefix}/test-nginx-0.24/inc/* /usr/local/share/perl5/site_perl/
 
 ENV LUA_RESTY_HTTP_VERSION 0.07
 RUN echo " ... installing lua-resty-http..." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,7 @@ RUN echo " ... installing aws-cli ..." \
 ENV HMAC_LUA_VERSION 1.0.0
 RUN echo " ... installing api-gateway-hmac ..." \
     && apk update \
-    && apk add make \
+    && apk add make perl-utils\
     && mkdir -p /tmp/api-gateway \
     && curl -L https://github.com/adobe-apiplatform/api-gateway-hmac/archive/${HMAC_LUA_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz \
     && tar -xf /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz -C /tmp/api-gateway/ \
@@ -303,7 +303,7 @@ RUN echo " ... installing api-gateway-async-logger ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ZMQ_ADAPTOR_VERSION 0.2.1
+ENV ZMQ_ADAPTOR_VERSION 0235b04f39a480b5347411c278900e5c57874cf5
 RUN echo " ... installing api-gateway-zmq-adaptor" \
          && curl -L https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
          && apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,27 +178,23 @@ RUN echo " ... installing lua-resty-iputils..." \
     && rm -rf /tmp/api-gateway
 
 ENV CONFIG_SUPERVISOR_VERSION 1.0.3
-ENV GOPATH /usr/lib/go/bin
+ENV GOPATH /tmp/go
 ENV GOBIN  /usr/lib/go/bin
 ENV PATH   $PATH:/usr/lib/go/bin
 RUN echo " ... installing api-gateway-config-supervisor  ... " \
     && echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk update \
     && apk add gcc make git 'go' \
-    && mkdir -p /tmp/api-gateway \
+    && mkdir -p /tmp/api-gateway /usr/local/sbin \
     && curl -L https://github.com/adobe-apiplatform/api-gateway-config-supervisor/archive/${CONFIG_SUPERVISOR_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
     && cd /tmp/api-gateway \
     && tar -xf /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
-    && mkdir -p /tmp/go \
-    && mv /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}/* /tmp/go \
-    && cd /tmp/go \
+    && mkdir -p ${GOPATH}/src/github.com/adobe-apiplatform/api-gateway-config-supervisor/ \
+    && mv /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}/* ${GOPATH}/src/github.com/adobe-apiplatform/api-gateway-config-supervisor/ \
+    && cd ${GOPATH}/src/github.com/adobe-apiplatform/api-gateway-config-supervisor/ \
     && make setup \
-    && mkdir -p /tmp/go/Godeps/_workspace \
-    && ln -s /tmp/go/vendor /tmp/go/Godeps/_workspace/src \
-    && mkdir -p /tmp/go-src/src/github.com/adobe-apiplatform \
-    && ln -s /tmp/go /tmp/go-src/src/github.com/adobe-apiplatform/api-gateway-config-supervisor \
-    && GOPATH=/tmp/go/vendor:/tmp/go-src CGO_ENABLED=0 GOOS=linux /usr/lib/go/bin/godep  go build -ldflags "-s" -a -installsuffix cgo -o api-gateway-config-supervisor ./ \
-    && mv /tmp/go/api-gateway-config-supervisor /usr/local/sbin/ \
+    && godep go build -ldflags "-s" -a -installsuffix cgo -o api-gateway-config-supervisor ./ \
+    && mv ./api-gateway-config-supervisor /usr/local/sbin/ \
 
     && echo "installing rclone sync ... skipped due to https://github.com/ncw/rclone/issues/663 ... " \
     # && go get github.com/ncw/rclone \

--- a/Dockerfile
+++ b/Dockerfile
@@ -305,7 +305,9 @@ RUN echo " ... installing api-gateway-async-logger ..." \
 
 ENV ZMQ_ADAPTOR_VERSION 0235b04f39a480b5347411c278900e5c57874cf5
 RUN echo " ... installing api-gateway-zmq-adaptor" \
-         && curl -L https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
+         && ZMQ_ADAPTOR_SHA256=d1aa7b70f5acfbf344508cdcac0d87401829b3073616dcf15dcfe337196ebcdc \
+         && curl -sL https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
+         && echo "${ZMQ_ADAPTOR_SHA256}  /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION}" | sha256sum -c - \
          && apk update \
          && apk add check-dev g++ gcc \
          && cd /tmp/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,9 +147,9 @@ RUN  echo " ... adding Openresty and PCRE" \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV TEST_NGINX_VERSION 0.26
+ENV TEST_NGINX_VERSION 0.24
 RUN echo " ... adding Nginx Test support..." \
-    && TEST_NGINX_SHA256=c3ece8cac16be1934aa07861aa5cbd8c9df09caeeeba03781c520964c464d1ab \
+    && TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3 \
     && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx.tar.gz \
     && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx.tar.gz" | sha256sum -c - \
     && cd ${_prefix} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # From https://hub.docker.com/_/alpine/
 # alpine:3.4 if go <1.7
-FROM alpine:3.4
+FROM alpine:3.8
 
 # install dependencies
 RUN apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ RUN echo " ... installing api-gateway-config-supervisor  ... " \
     && make setup \
     && godep go build -ldflags "-s" -a -installsuffix cgo -o api-gateway-config-supervisor ./ \
     && mv ./api-gateway-config-supervisor /usr/local/sbin/ \
-
+    \
     && echo "installing rclone sync ... skipped due to https://github.com/ncw/rclone/issues/663 ... " \
     # && go get github.com/ncw/rclone \
     # && mv /usr/lib/go/bin/rclone /usr/local/sbin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,15 +149,15 @@ RUN  echo " ... adding Openresty and PCRE" \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV TEST_NGINX_VERSION 0.24
+ENV TEST_NGINX_VERSION 0.26
 RUN echo " ... adding Nginx Test support..." \
-    && TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3 \
+    && TEST_NGINX_SHA256=c3ece8cac16be1934aa07861aa5cbd8c9df09caeeeba03781c520964c464d1ab \
     && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz" | sha256sum -c - \
     && cd ${_prefix} \
     && tar -xf ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && rm ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
-    && cp -r ${_prefix}/test-nginx-0.24/inc/* /usr/local/share/perl5/site_perl/
+    && cp -r ${_prefix}/test-nginx-${TEST_NGINX_VERSION}/inc/* /usr/local/share/perl5/site_perl/
 
 ENV LUA_RESTY_HTTP_VERSION 0.07
 RUN echo " ... installing lua-resty-http..." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ RUN apk update \
     perl-test-longstring perl-list-moreutils perl-http-message \
     geoip-dev sudo
 
-ENV ZMQ_VERSION 4.0.5
-ENV CZMQ_VERSION 2.2.0
+ENV ZMQ_VERSION=4.0.5 \
+    ZMQ_SHA256=e3dc99aeacd4e1e7a025f22f92afec6c381b82f0e29222d27e1256ada841e43f
+ENV CZMQ_VERSION=2.2.0 \
+    CZMQ_SHA256=3c95aab7434ac0a074a46217122c9f454c36befcd0b5aaa1f463aae0838dd499
 
 # Installing throttling dependencies
 RUN echo " ... adding throttling support with ZMQ and CZMQ" \
          && apk add autoconf automake \
-         && curl -L https://github.com/zeromq/zeromq4-x/archive/v${ZMQ_VERSION}.tar.gz -o /tmp/zeromq.tar.gz \
+         && curl -sL https://github.com/zeromq/zeromq4-x/archive/v${ZMQ_VERSION}.tar.gz -o /tmp/zeromq.tar.gz \
+         && echo "${ZMQ_SHA256}  /tmp/zeromq.tar.gz" | sha256sum -c - \
          && cd /tmp/ \
          && tar -xf /tmp/zeromq.tar.gz \
          && cd /tmp/zeromq*/ \
@@ -29,7 +32,8 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
                         --mandir=/usr/share/man \
                         --infodir=/usr/share/info \
          && make && make install \
-         && curl -L https://github.com/zeromq/czmq/archive/v${CZMQ_VERSION}.tar.gz -o /tmp/czmq.tar.gz \
+         && curl -sL https://github.com/zeromq/czmq/archive/v${CZMQ_VERSION}.tar.gz -o /tmp/czmq.tar.gz \
+         && echo "${CZMQ_SHA256}  /tmp/czmq.tar.gz" | sha256sum -c - \
          && cd /tmp/ \
          && tar -xf /tmp/czmq.tar.gz \
          && cd /tmp/czmq*/ \
@@ -45,9 +49,12 @@ RUN echo " ... adding throttling support with ZMQ and CZMQ" \
 
 # openresty build
 ENV OPENRESTY_VERSION=1.13.6.1 \
-    PCRE_VERSION=8.37 \
-    TEST_NGINX_VERSION=0.24 \
-    _prefix=/usr/local \
+    OPENRESTY_SHA256=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b
+ENV PCRE_VERSION=8.37 \
+    PCRE_SHA256=19d490a714274a8c4c9d131f651489b8647cdb40a159e9fb7ce17ba99ef992ab
+ENV TEST_NGINX_VERSION=0.24 \
+    TEST_NGINX_SHA256=a98083e801a7a088231da1e3a5e0d3aab743f07ffc65ede48fe8a7de132db9b3
+ENV _prefix=/usr/local \
     _exec_prefix=/usr/local \
     _localstatedir=/var \
     _sysconfdir=/etc \
@@ -55,16 +62,17 @@ ENV OPENRESTY_VERSION=1.13.6.1 \
 
 RUN  echo " ... adding Openresty, NGINX, and PCRE" \
      && mkdir -p /tmp/api-gateway \
-     && readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
-     && echo "using up to $NPROC threads" \
-
+     \
      && cd /tmp/api-gateway/ \
-     && curl -L https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/pcre-${PCRE_VERSION}.tar.gz -o /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz \
-     && curl -L https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/openresty-${OPENRESTY_VERSION}.tar.gz -o /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz \
+     && curl -sL https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/pcre-${PCRE_VERSION}.tar.gz -o /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz \
+     && echo "${PCRE_SHA256}  /tmp/api-gateway/pcre-${PCRE_VERSION}.tar.gz" | sha256sum -c - \
+     && curl -sL https://s3.amazonaws.com/adobe-cloudops-apip-installers-ue1/3rd-party/openresty-${OPENRESTY_VERSION}.tar.gz -o /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz \
+     && echo "${OPENRESTY_SHA256}  /tmp/api-gateway/openresty-${OPENRESTY_VERSION}.tar.gz" | sha256sum -c - \
      && tar -zxf ./openresty-${OPENRESTY_VERSION}.tar.gz \
-     && tar -zxf ./pcre-${PCRE_VERSION}.tar.gz \
+     && tar -zxf ./pcre-${PCRE_VERSION}.tar.gz
+RUN readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
+     && echo "using up to $NPROC threads" \
      && cd /tmp/api-gateway/openresty-${OPENRESTY_VERSION} \
-
      && echo "        - building debugging version of the api-gateway ... " \
      && ./configure \
             --prefix=${_exec_prefix}/api-gateway \
@@ -101,7 +109,7 @@ RUN  echo " ... adding Openresty, NGINX, and PCRE" \
             -j${NPROC} \
     && make -j${NPROC} \
     && make install \
-
+    \
     && echo "        - building regular version of the api-gateway ... " \
     && ./configure \
             --prefix=${_exec_prefix}/api-gateway \
@@ -135,27 +143,29 @@ RUN  echo " ... adding Openresty, NGINX, and PCRE" \
             --without-http_scgi_module \
             -j${NPROC} \
     && make -j${NPROC} \
-    && make install \
+    && make install
 
-    && echo "        - adding Nginx Test support" \
-    && curl -L https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
+RUN echo "        - adding Nginx Test support" \
+    && curl -sL https://github.com/openresty/test-nginx/archive/v${TEST_NGINX_VERSION}.tar.gz -o ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
+    && echo "${TEST_NGINX_SHA256}  ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz" | sha256sum -c - \
     && cd ${_prefix} \
     && tar -xf ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && rm ${_prefix}/test-nginx-${TEST_NGINX_VERSION}.tar.gz \
     && cp -r ${_prefix}/test-nginx-0.24/inc/* /usr/local/share/perl5/site_perl/ \
-
     && ln -s ${_sbindir}/api-gateway-debug ${_sbindir}/nginx \
     && cp /tmp/api-gateway/openresty-${OPENRESTY_VERSION}/build/install ${_prefix}/api-gateway/bin/resty-install \
     && apk del g++ gcc make \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV LUA_RESTY_HTTP_VERSION 0.07
+ENV LUA_RESTY_HTTP_VERSION=0.07 \
+    LUA_RESTY_HTTP_SHA256=1c6aa06c9955397c94e9c3e0c0fba4e2704e85bee77b4512fb54ae7c25d58d86
 RUN echo " ... installing lua-resty-http..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/pintsized/lua-resty-http/archive/v${LUA_RESTY_HTTP_VERSION}.tar.gz -o /tmp/api-gateway/lua-resty-http-${LUA_RESTY_HTTP_VERSION}.tar.gz \
+    && curl -sL https://github.com/pintsized/lua-resty-http/archive/v${LUA_RESTY_HTTP_VERSION}.tar.gz -o /tmp/api-gateway/lua-resty-http-${LUA_RESTY_HTTP_VERSION}.tar.gz \
+    && echo "${LUA_RESTY_HTTP_SHA256}  /tmp/api-gateway/lua-resty-http-${LUA_RESTY_HTTP_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/lua-resty-http-${LUA_RESTY_HTTP_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/lua-resty-http-${LUA_RESTY_HTTP_VERSION} \
     && make install \
@@ -163,12 +173,14 @@ RUN echo " ... installing lua-resty-http..." \
             INSTALL=${_prefix}/api-gateway/bin/resty-install \
     && rm -rf /tmp/api-gateway
 
-ENV LUA_RESTY_IPUTILS_VERSION 0.2.0
+ENV LUA_RESTY_IPUTILS_VERSION=0.2.0 \
+    LUA_RESTY_IPUTILS_SHA256=7962557ff3070154a45c5192d927b26106ec2f411fd1a98eaf770bc23189799d
 RUN echo " ... installing lua-resty-iputils..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/hamishforbes/lua-resty-iputils/archive/v${LUA_RESTY_IPUTILS_VERSION}.tar.gz -o /tmp/api-gateway/lua-resty-iputils-${LUA_RESTY_IPUTILS_VERSION}.tar.gz \
+    && curl -sL https://github.com/hamishforbes/lua-resty-iputils/archive/v${LUA_RESTY_IPUTILS_VERSION}.tar.gz -o /tmp/api-gateway/lua-resty-iputils-${LUA_RESTY_IPUTILS_VERSION}.tar.gz \
+    && echo "${LUA_RESTY_IPUTILS_SHA256}  /tmp/api-gateway/lua-resty-iputils-${LUA_RESTY_IPUTILS_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/lua-resty-iputils-${LUA_RESTY_IPUTILS_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/lua-resty-iputils-${LUA_RESTY_IPUTILS_VERSION} \
     && export LUA_LIB_DIR=${_prefix}/api-gateway/lualib \
@@ -177,7 +189,9 @@ RUN echo " ... installing lua-resty-iputils..." \
     && $INSTALL lib/resty/*.lua ${LUA_LIB_DIR}/resty/ \
     && rm -rf /tmp/api-gateway
 
-ENV CONFIG_SUPERVISOR_VERSION 1.0.3
+ENV CONFIG_SUPERVISOR_VERSION=1.0.3 \
+    CONFIG_SUPERVISOR_SHA256=9a323d93897140f3ccb384a7279335d69f5659d1d29564b21f3d056f42272bdb
+
 ENV GOPATH /usr/lib/go/bin
 ENV GOBIN  /usr/lib/go/bin
 ENV PATH   $PATH:/usr/lib/go/bin
@@ -186,7 +200,8 @@ RUN echo " ... installing api-gateway-config-supervisor  ... " \
     && apk update \
     && apk add gcc make git 'go' \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-config-supervisor/archive/${CONFIG_SUPERVISOR_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-config-supervisor/archive/${CONFIG_SUPERVISOR_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
+    && echo "${CONFIG_SUPERVISOR_SHA256}  /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz" | sha256sum -c - \
     && cd /tmp/api-gateway \
     && tar -xf /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz \
     && mkdir -p /tmp/go \
@@ -220,12 +235,14 @@ RUN echo " ... installing aws-cli ..." \
     && pip install --upgrade pip \
     && pip install awscli
 
-ENV HMAC_LUA_VERSION 1.0.0
+ENV HMAC_LUA_VERSION=1.0.0 \
+    HMAC_LUA_SHA256=53e6183cb3812418b55b9afba256f6d1f149cdd994c0c19df3bb70ac56310281
 RUN echo " ... installing api-gateway-hmac ..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-hmac/archive/${HMAC_LUA_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-hmac/archive/${HMAC_LUA_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz \
+    && echo "${HMAC_LUA_SHA256}  /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-hmac-${HMAC_LUA_VERSION} \
     && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -235,12 +252,14 @@ RUN echo " ... installing api-gateway-hmac ..." \
             INSTALL=${_prefix}/api-gateway/bin/resty-install \
     && rm -rf /tmp/api-gateway
 
-ENV CACHE_MANAGER_VERSION 1.0.1
+ENV CACHE_MANAGER_VERSION=1.0.1 \
+    CACHE_MANAGER_SHA256=8d03c1b4a9b3d6ca9fcbf941c42c5795d12fe2fd3d2e58b56e33888acb993f26
 RUN echo " ... installing api-gateway-cachemanager..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-cachemanager/archive/${CACHE_MANAGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-cachemanager/archive/${CACHE_MANAGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz \
+    && echo "${CACHE_MANAGER_SHA256}  /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-cachemanager-${CACHE_MANAGER_VERSION} \
     && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -253,12 +272,14 @@ RUN echo " ... installing api-gateway-cachemanager..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV AWS_VERSION 1.7.1
+ENV AWS_VERSION=1.7.1 \
+    AWS_SHA256=d9fadd6602e2c139d389bd64329c72c129f76ad1d1c1857c2e4a3537d01e12fe
 RUN echo " ... installing api-gateway-aws ..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-aws/archive/${AWS_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-aws/archive/${AWS_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz \
+    && echo "${AWS_SHA256}  /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-aws-${AWS_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-aws-${AWS_VERSION} \
     && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -269,12 +290,14 @@ RUN echo " ... installing api-gateway-aws ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV REQUEST_VALIDATION_VERSION 1.2.4
+ENV REQUEST_VALIDATION_VERSION=1.2.4 \
+    REQUEST_VALIDATION_SHA256=44ebce6119b6d3e1405a1fc203d97c9cb64d4a37ee8e26e00a0eec2b5814e176
 RUN echo " ... installing api-gateway-request-validation ..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-request-validation/archive/${REQUEST_VALIDATION_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-request-validation/archive/${REQUEST_VALIDATION_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz \
+    && echo "${REQUEST_VALIDATION_SHA256}  /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-request-validation-${REQUEST_VALIDATION_VERSION} \
     && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -287,12 +310,14 @@ RUN echo " ... installing api-gateway-request-validation ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ASYNC_LOGGER_VERSION 1.0.1
+ENV ASYNC_LOGGER_VERSION=1.0.1 \
+    ASYNC_LOGGER_SHA256=de5e008d189daa619a189a8bb530ed1c58c29f8bf07903b26b818dadd4bcc8fa
 RUN echo " ... installing api-gateway-async-logger ..." \
     && apk update \
     && apk add make \
     && mkdir -p /tmp/api-gateway \
-    && curl -L https://github.com/adobe-apiplatform/api-gateway-async-logger/archive/${ASYNC_LOGGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz \
+    && curl -sL https://github.com/adobe-apiplatform/api-gateway-async-logger/archive/${ASYNC_LOGGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz \
+    && echo "${ASYNC_LOGGER_SHA256}  /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
     && cd /tmp/api-gateway/api-gateway-async-logger-${ASYNC_LOGGER_VERSION} \
     && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -303,9 +328,11 @@ RUN echo " ... installing api-gateway-async-logger ..." \
     && rm -rf /var/cache/apk/* \
     && rm -rf /tmp/api-gateway
 
-ENV ZMQ_ADAPTOR_VERSION 0.2.1
+ENV ZMQ_ADAPTOR_VERSION=0.2.1 \
+    ZMQ_ADAPTOR_SHA256=10cc0fd0b431931c8d05ab112e7e8e76aaf8848af5f3e48adf41d4bd0e329272
 RUN echo " ... installing api-gateway-zmq-adaptor" \
-         && curl -L https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
+         && curl -sL https://github.com/adobe-apiplatform/api-gateway-zmq-adaptor/archive/${ZMQ_ADAPTOR_VERSION}.tar.gz -o /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION} \
+         && echo "${ZMQ_ADAPTOR_SHA256}  /tmp/api-gateway-zmq-adaptor-${ZMQ_ADAPTOR_VERSION}" | sha256sum -c - \
          && apk update \
          && apk add check-dev g++ gcc \
          && cd /tmp/ \
@@ -317,10 +344,12 @@ RUN echo " ... installing api-gateway-zmq-adaptor" \
          && apk del check-dev g++ gcc \
          && rm -rf /var/cache/apk/*
 
-ENV ZMQ_LOGGER_VERSION 1.0.0
+ENV ZMQ_LOGGER_VERSION=1.0.0 \
+    ZMQ_LOGGER_SHA256=76afbe17397881719bf24775747276231841274976708cca8d3b37d6b95e61c8
 RUN echo " ... installing api-gateway-zmq-logger ..." \
         && mkdir -p /tmp/api-gateway \
-        && curl -L https://github.com/adobe-apiplatform/api-gateway-zmq-logger/archive/${ZMQ_LOGGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz \
+        && curl -sL https://github.com/adobe-apiplatform/api-gateway-zmq-logger/archive/${ZMQ_LOGGER_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz \
+        && echo "${ZMQ_LOGGER_SHA256}  /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz" | sha256sum -c - \
         && tar -xf /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION}.tar.gz -C /tmp/api-gateway/ \
         && cd /tmp/api-gateway/api-gateway-zmq-logger-${ZMQ_LOGGER_VERSION} \
         && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -330,10 +359,12 @@ RUN echo " ... installing api-gateway-zmq-logger ..." \
              INSTALL=/usr/local/api-gateway/bin/resty-install \
         && rm -rf /tmp/api-gateway
 
-ENV REQUEST_TRACKING_VERSION 1.0.1
+ENV REQUEST_TRACKING_VERSION=1.0.1 \
+    REQUEST_TRACKING_SHA256=6508d4eb444e0ae46bef262e0dd1def25f5762993e1810c21f1603ec57ce8895
 RUN echo " ... installing api-gateway-request-tracking ..." \
         && mkdir -p /tmp/api-gateway \
-        && curl -L https://github.com/adobe-apiplatform/api-gateway-request-tracking/archive/${REQUEST_TRACKING_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz \
+        && curl -sL https://github.com/adobe-apiplatform/api-gateway-request-tracking/archive/${REQUEST_TRACKING_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz \
+        && echo "${REQUEST_TRACKING_SHA256}  /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz" | sha256sum -c - \
         && tar -xf /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION}.tar.gz -C /tmp/api-gateway/ \
         && cd /tmp/api-gateway/api-gateway-request-tracking-${REQUEST_TRACKING_VERSION} \
         && cp -r /usr/local/test-nginx-${TEST_NGINX_VERSION}/* ./test/resources/test-nginx/ \
@@ -345,8 +376,10 @@ RUN echo " ... installing api-gateway-request-tracking ..." \
         # && apk del redis \
         && rm -rf /tmp/api-gateway
 
-RUN \
-    curl -L -k -s -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+ENV JQ_VERSION=1.5 \
+    JQ_SHA256=c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -o /usr/local/bin/jq \
+    && echo "${JQ_SHA256}  /usr/local/bin/jq" | sha256sum -c - \
     && apk update \
     && apk add gawk \
     && chmod 755 /usr/local/bin/jq \


### PR DESCRIPTION
PR grouping all three #71 #73 #74 + test-nginx 0.24 -> 0.26:
- Verify checksums of downloaded files in Dockerfile 
- Update to Alpine 3.8 to fix alpine vulnerability 
- Gofix for #72 
- test-nginx 0.24 -> 0.26