### PR TITLE
fix: explicitly pass active-active env vars

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -26,6 +26,14 @@ log_level=${LOG_LEVEL:-warn}
 marathon_host=${MARATHON_HOST}
 sleep_duration=${MARATHON_POLL_INTERVAL:-5}
 force_reload_interval_s=${FORCE_RELOAD_INTERVAL_S:--1}
+active_active_api_gateway_token=${ACTIVE_ACTIVE_API_GATEWAY_TOKEN}
+active_active_namespace_0=${ACTIVE_ACTIVE_NAMESPACE_0}
+active_active_namespace_1=${ACTIVE_ACTIVE_NAMESPACE_1}
+active_active_set_upstream_interval=${ACTIVE_ACTIVE_SET_UPSTREAM_INTERVAL}
+active_active_status_check_interval=${ACTIVE_ACTIVE_STATUS_CHECK_INTERVAL}
+active_active_upstreams_csv_path=${ACTIVE_ACTIVE_UPSTREAMS_CSV_PATH}
+active_active_weight_0=${ACTIVE_ACTIVE_WEIGHT_0}
+active_active_weight_1=${ACTIVE_ACTIVE_WEIGHT_1}
 active_active=${ACTIVE_ACTIVE:-false}
 
 #
@@ -125,4 +133,4 @@ else
 fi
 
 echo "   ... using log level: '${log_level}'. Override it with -e 'LOG_LEVEL=<level>' "
-sudo -E api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "daemon off; error_log /dev/stderr ${log_level}; env ACTIVE_ACTIVE=${active_active};"
+sudo api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "daemon off; error_log /dev/stderr ${log_level}; env ACTIVE_ACTIVE=${active_active}; env ACTIVE_ACTIVE_API_GATEWAY_TOKEN=${active_active_api_gateway_token}; env ACTIVE_ACTIVE_NAMESPACE_0=${active_active_namespace_0}; env ACTIVE_ACTIVE_NAMESPACE_1=${active_active_namespace_1}; env ACTIVE_ACTIVE_SET_UPSTREAM_INTERVAL=${active_active_set_upstream_interval}; env ACTIVE_ACTIVE_STATUS_CHECK_INTERVAL=${active_active_status_check_interval}; env ACTIVE_ACTIVE_UPSTREAMS_CSV_PATH=${active_active_upstreams_csv_path}; env ACTIVE_ACTIVE_WEIGHT_0=${active_active_weight_0}; env ACTIVE_ACTIVE_WEIGHT_1=${active_active_weight_1};"


### PR DESCRIPTION
### Changes

- Explicitly pass active-active environment variables so that the functionality will actually work

### Testing

I used the snapshot image produced by [this build](https://aio-runtime.ci.corp.adobe.com/job/apigateway-build/job/main/52/) in the delivery facade deployment (with active-active enabled) in [stg-va6](https://argocd-flexbox-002.ethos.corp.adobe.com/applications/bladerunner--delivery-facade-deploy--ethos651-stage-va-993a3b5a?rollback=-1&operation=false&conditions=false&resource=) and [stg-irl1](https://argocd-flexbox-002.ethos.corp.adobe.com/applications/bladerunner--delivery-facade-deploy--ethos651-stage-ir-0ee0a212?resource=) (see [26915f3](https://git.corp.adobe.com/bladerunner/delivery-facade-deploy/commit/26915f3560b867ac73317fd76e8c008fa52fa099)) and both came up as expected.

### Related Issues

- Follow-up to [#82](https://github.com/adobe-apiplatform/apigateway/pull/82)

### Notes

I thought that the image I was using for testing [#82](https://github.com/adobe-apiplatform/apigateway/pull/82) was https://github.com/adobe-apiplatform/apigateway/pull/82/commits/ade1ef4e25870744d10e1a1755fc8a1687526b73, but it actually didn't include that change (the working image was the one up through https://github.com/adobe-apiplatform/apigateway/pull/82/commits/a5b537733ba15b695fe967aeb46b1ec54eb89dce). This change fixes that.